### PR TITLE
Explicitly shut down Adhersion

### DIFF
--- a/lib/switest/adhearsion.rb
+++ b/lib/switest/adhearsion.rb
@@ -33,6 +33,11 @@ module Switest
       ::Adhearsion::Plugin.run_plugins
       ::Adhearsion::Rayo::Initializer.run
       @started = true
+
+      at_exit {
+        ::Adhearsion::Process.shutdown
+      }
+
       true
     end
 


### PR DESCRIPTION
At the end of each test run, there is a 5 second delay.

I don't understand this fully, but if we shut down Adhersion explicitly, the delay goes away, and we prevent the following error (raised [here](https://github.com/adhearsion/adhearsion/blob/b8692af19b40a91a28d487746a72921bdd0d5a7d/lib/adhearsion/rayo/initializer.rb#L107)):
`ERROR Adhearsion::Rayo::Initializer: Connection lost. Attempting reconnect 1 of Infinity` 
