### PR TITLE
Support reject and pass args

### DIFF
--- a/lib/switest/agent.rb
+++ b/lib/switest/agent.rb
@@ -27,12 +27,16 @@ module Switest
       @call = ::Adhearsion::OutboundCall.originate(*args)
     end
 
-    def answer
-      @call.answer
+    def answer(*args)
+      @call.answer(*args)
     end
 
-    def hangup
-      @call.hangup
+    def hangup(*args)
+      @call.hangup(*args)
+    end
+
+    def reject(*args)
+      @call.reject(*args)
     end
 
     def send_dtmf(dtmf)


### PR DESCRIPTION
We need the ability to reject calls.

`hangup` sends `480 Temporarily Unavailable` for unanswered calls, but sometimes we want e.g. `486 Busy Here`.

Also, allow passing arguments through to answer/hangup/reject (they all take an optional `headers` argument, https://github.com/adhearsion/adhearsion/blob/b114a94ac13cc34d71bebd90d6e09a7484f679c4/lib/adhearsion/call.rb#L326).