### PR TITLE
Add wait_for_media and rename wait: to timeout:

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,14 +111,14 @@ bob.answer
 | Method                        | Direction    | What it does                                |
 |-------------------------------|-------------|---------------------------------------------|
 | `wait_for_answer(timeout:)`   | Outbound    | Passively waits for the remote to answer    |
-| `answer(wait:)`               | Inbound     | Actively answers the call                   |
+| `answer(timeout:)`            | Inbound     | Actively answers the call                   |
 
 #### wait_for_end vs hangup
 
 | Method                   | Use case              | What it does                         |
 |--------------------------|-----------------------|--------------------------------------|
 | `wait_for_end(timeout:)` | Remote hangs up       | Passively waits for the call to end  |
-| `hangup(wait:)`          | You hang up           | Sends hangup and waits               |
+| `hangup(timeout:)`       | You hang up           | Sends hangup and waits               |
 
 ## API Reference
 
@@ -134,11 +134,12 @@ Agent.listen_for_call(guards)  # e.g. to: /pattern/, from: /pattern/
 #### Actions
 
 ```ruby
-agent.answer(wait: 5)             # Answer an inbound call
-agent.hangup(wait: 5)             # Hang up
-agent.reject(reason = :decline)   # Reject inbound call (:decline or :busy)
-agent.send_dtmf(digits)           # Send DTMF tones
-agent.receive_dtmf(count:, timeout:)  # Receive DTMF digits
+agent.answer(timeout: 5)                # Answer and wait for answer
+agent.answer(wait: :media, timeout: 5)  # Answer and wait for media (DTMF-ready)
+agent.hangup(timeout: 5)                # Hang up
+agent.reject(reason = :decline)         # Reject inbound call (:decline or :busy)
+agent.send_dtmf(digits)                 # Send DTMF tones
+agent.receive_dtmf(count:, timeout:)    # Receive DTMF digits
 ```
 
 #### Waits
@@ -147,6 +148,7 @@ agent.receive_dtmf(count:, timeout:)  # Receive DTMF digits
 agent.wait_for_call(timeout: 5)    # Wait for inbound call to arrive
 agent.wait_for_answer(timeout: 5)  # Wait for call to be answered
 agent.wait_for_bridge(timeout: 5)  # Wait for call to be bridged
+agent.wait_for_media(timeout: 5)   # Wait for media path (RTP) to be ready
 agent.wait_for_end(timeout: 5)     # Wait for call to end
 ```
 

--- a/lib/switest/agent.rb
+++ b/lib/switest/agent.rb
@@ -47,14 +47,14 @@ module Switest
       !@call.nil?
     end
 
-    def answer(wait: 5)
+    def answer(wait: :answer, timeout: 5)
       raise "No call to answer" unless @call
-      @call.answer(wait: wait)
+      @call.answer(wait: wait, timeout: timeout)
     end
 
-    def hangup(wait: 5)
+    def hangup(timeout: 5)
       raise "No call to hangup" unless @call
-      @call.hangup(wait: wait)
+      @call.hangup(timeout: timeout)
     end
 
     def reject(reason = :decline)
@@ -89,6 +89,11 @@ module Switest
     def wait_for_bridge(timeout: 5)
       raise "No call to wait for" unless @call
       @call.wait_for_bridge(timeout: timeout)
+    end
+
+    def wait_for_media(timeout: 5)
+      raise "No call to wait for" unless @call
+      @call.wait_for_media(timeout: timeout)
     end
 
     def wait_for_end(timeout: 5)

--- a/test/unit/switest/agent_test.rb
+++ b/test/unit/switest/agent_test.rb
@@ -143,7 +143,7 @@ class Switest::AgentTest < Minitest::Test
     )
     agent = Switest::Agent.new(call)
 
-    agent.answer(wait: false)
+    agent.answer(timeout: false)
 
     assert @connection.commands_sent.any? { |cmd| cmd.include?("answer") }
   end
@@ -157,7 +157,7 @@ class Switest::AgentTest < Minitest::Test
     )
     agent = Switest::Agent.new(call)
 
-    agent.hangup(wait: false)
+    agent.hangup(timeout: false)
 
     assert @connection.commands_sent.any? { |cmd| cmd.include?("hangup") }
   end

--- a/test/unit/switest/esl/call_test.rb
+++ b/test/unit/switest/esl/call_test.rb
@@ -305,8 +305,8 @@ class Switest::ESL::CallTest < Minitest::Test
       direction: :outbound
     )
 
-    inbound.answer(wait: false)
-    outbound.answer(wait: false)
+    inbound.answer(timeout: false)
+    outbound.answer(timeout: false)
 
     # Only inbound should have sent the answer command
     answer_commands = @connection.commands_sent.select { |c| c.include?("answer") }
@@ -320,7 +320,7 @@ class Switest::ESL::CallTest < Minitest::Test
       direction: :outbound
     )
 
-    call.hangup("USER_BUSY", wait: false)
+    call.hangup("USER_BUSY", timeout: false)
 
     command = @connection.commands_sent.last
     assert_match(/call-command: hangup/, command)
@@ -334,7 +334,7 @@ class Switest::ESL::CallTest < Minitest::Test
       direction: :outbound
     )
 
-    call.hangup(wait: false)
+    call.hangup(timeout: false)
 
     command = @connection.commands_sent.last
     assert_match(/hangup-cause: NORMAL_CLEARING/, command)
@@ -347,7 +347,7 @@ class Switest::ESL::CallTest < Minitest::Test
       direction: :inbound
     )
 
-    call.reject(:busy, wait: false)
+    call.reject(:busy, timeout: false)
 
     command = @connection.commands_sent.last
     assert_match(/hangup-cause: USER_BUSY/, command)
@@ -360,7 +360,7 @@ class Switest::ESL::CallTest < Minitest::Test
       direction: :inbound
     )
 
-    call.reject(:decline, wait: false)
+    call.reject(:decline, timeout: false)
 
     command = @connection.commands_sent.last
     assert_match(/hangup-cause: CALL_REJECTED/, command)


### PR DESCRIPTION
## Summary

- **Rename `wait:` to `timeout:`** on `answer`, `hangup`, and `reject` for clarity — `wait:` on those methods was a timeout value, not a boolean
- **Add `wait_for_media`** to block until FreeSWITCH reports the media path (RTP) is ready via `CHANNEL_STATE` events (`CS_CONSUME_MEDIA` / `CS_EXCHANGE_MEDIA`)
- **Repurpose `wait:` on `answer`** to select *what* to wait for: `:answer` (default) or `:media` (DTMF-ready)

### Why

DTMF sent via `tone_stream://` (in-band audio) requires an active media path. With loopback channels, `CHANNEL_ANSWER` fires before RTP is established, causing a race condition. `wait: :media` lets tests block until media is flowing before sending/receiving DTMF.

### Usage

```ruby
bob.answer(wait: :media)        # answer and wait for media
bob.answer(wait: :media, timeout: 10)  # with custom timeout
bob.wait_for_media(timeout: 5)  # explicit wait after answer
```