### PR TITLE
Add block support to assert_dtmf to avoid stale DTMF

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,7 +172,8 @@ assert_call(agent, timeout: 5)         # Agent receives a call
 assert_no_call(agent, timeout: 2)      # Agent does NOT receive a call
 assert_hungup(agent, timeout: 5)       # Call has ended
 assert_not_hungup(agent, timeout: 2)   # Call is still active
-assert_dtmf(agent, "123", timeout: 5)  # Agent receives expected DTMF digits
+assert_dtmf(agent, "123", timeout: 5)              # Agent receives expected DTMF digits
+assert_dtmf(agent, "123") { other.send_dtmf("123") } # With block: flushes stale DTMF first
 ```
 
 The `hangup_all` helper ends all active calls (useful before CDR assertions):
@@ -228,7 +229,22 @@ digits = alice.receive_dtmf(count: 4, timeout: 5)
 assert_equal "1234", digits
 ```
 
-Or use the assertion helper:
+Or use the assertion helper with a block to avoid stale DTMF issues.
+The block is executed after a configurable delay (`after:`, default 1s)
+while the assertion is already listening:
+
+```ruby
+assert_dtmf(bob, "1234") do
+  alice.send_dtmf("1234")
+end
+
+# With custom delay and timeout:
+assert_dtmf(bob, "1234", timeout: 10, after: 0.5) do
+  alice.send_dtmf("1234")
+end
+```
+
+Without a block it works as a simple wait (backward compatible):
 
 ```ruby
 assert_dtmf(alice, "1234", timeout: 5)

--- a/lib/switest/agent.rb
+++ b/lib/switest/agent.rb
@@ -72,6 +72,11 @@ module Switest
       @call.receive_dtmf(count: count, timeout: timeout)
     end
 
+    def flush_dtmf
+      raise "No call for DTMF" unless @call
+      @call.flush_dtmf
+    end
+
     def wait_for_call(timeout: 5)
       deadline = Time.now + timeout
       while Time.now < deadline

--- a/lib/switest/esl/call.rb
+++ b/lib/switest/esl/call.rb
@@ -98,6 +98,10 @@ module Switest
         play_audio("tone_stream://d=200;w=250;#{digits}", wait: wait)
       end
 
+      def flush_dtmf
+        @dtmf_buffer.clear
+      end
+
       def receive_dtmf(count: 1, timeout: 5)
         digits = String.new
         deadline = Time.now + timeout

--- a/test/integration/call_test.rb
+++ b/test/integration/call_test.rb
@@ -390,10 +390,9 @@ class CallIntegrationTest < Switest::Scenario
     alice.wait_for_bridge(timeout: 5)
 
     # Alice plays DTMF tones — B-leg's start_dtmf should detect them
-    alice.call.send_dtmf("789")
-
-    digits = bob.call.receive_dtmf(count: 3, timeout: 5)
-    assert_equal "789", digits, "Bob should receive DTMF digits from Alice"
+    assert_dtmf(bob, "789") do
+      alice.send_dtmf("789")
+    end
 
     alice.hangup
     bob.wait_for_end(timeout: 5)

--- a/test/unit/switest/esl/call_test.rb
+++ b/test/unit/switest/esl/call_test.rb
@@ -260,6 +260,22 @@ class Switest::ESL::CallTest < Minitest::Test
     assert_equal "123", digits
   end
 
+  def test_flush_dtmf_clears_buffer
+    call = Switest::ESL::Call.new(
+      id: "test-uuid",
+      connection: @connection,
+      direction: :inbound
+    )
+
+    call.handle_dtmf("1")
+    call.handle_dtmf("2")
+    call.flush_dtmf
+
+    call.handle_dtmf("3")
+    digits = call.receive_dtmf(count: 1, timeout: 1)
+    assert_equal "3", digits
+  end
+
   def test_dtmf_timeout
     call = Switest::ESL::Call.new(
       id: "test-uuid",


### PR DESCRIPTION
## Summary
- `assert_dtmf` now accepts an optional block (like `assert_raises`) to avoid stale DTMF in the buffer
- Flushes the DTMF buffer before listening, then executes the block after a configurable delay (`after:` param, default 1s) via `Concurrent::ScheduledTask`
- Adds `flush_dtmf` to `Call` and `Agent`
- Backward compatible: without a block, behaves as before