### PR TITLE
Add assert_answered and assert_bridged assertions

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,11 +168,13 @@ agent.end_reason  # e.g. "NORMAL_CLEARING"
 `Switest::Scenario` provides these assertions:
 
 ```ruby
-assert_call(agent, timeout: 5)         # Agent receives a call
-assert_no_call(agent, timeout: 2)      # Agent does NOT receive a call
-assert_hungup(agent, timeout: 5)       # Call has ended
-assert_not_hungup(agent, timeout: 2)   # Call is still active
-assert_dtmf(agent, "123", timeout: 5)              # Agent receives expected DTMF digits
+assert_call(agent, timeout: 5)                       # Agent receives a call
+assert_no_call(agent, timeout: 2)                    # Agent does NOT receive a call
+assert_answered(agent, timeout: 5)                   # Call has been answered
+assert_bridged(agent, timeout: 5)                    # Call has been bridged
+assert_hungup(agent, timeout: 5)                     # Call has ended
+assert_not_hungup(agent, timeout: 2)                 # Call is still active
+assert_dtmf(agent, "123", timeout: 5)                # Agent receives expected DTMF digits
 assert_dtmf(agent, "123") { other.send_dtmf("123") } # With block: flushes stale DTMF first
 ```
 

--- a/docker/freeswitch/dialplan.xml
+++ b/docker/freeswitch/dialplan.xml
@@ -25,6 +25,14 @@
     </condition>
   </extension>
 
+  <!-- Answer and bridge to echo (generates CHANNEL_BRIDGE events) -->
+  <extension name="switest-bridge-echo">
+    <condition field="destination_number" expression="^bridge_echo$">
+      <action application="answer"/>
+      <action application="bridge" data="loopback/echo/public"/>
+    </condition>
+  </extension>
+
   <!-- Inbound test with inband DTMF detection enabled -->
   <extension name="switest-dtmf-detect">
     <condition field="destination_number" expression="^dtmf_wait_test$">

--- a/lib/switest/scenario.rb
+++ b/lib/switest/scenario.rb
@@ -49,6 +49,18 @@ module Switest
       refute agent.call?, "Expected agent to not have received a call"
     end
 
+    def assert_answered(agent, timeout: 5)
+      assert agent.call?, "Agent has no call"
+      success = agent.wait_for_answer(timeout: timeout)
+      assert success, "Expected call to be answered within #{timeout} seconds"
+    end
+
+    def assert_bridged(agent, timeout: 5)
+      assert agent.call?, "Agent has no call"
+      success = agent.wait_for_bridge(timeout: timeout)
+      assert success, "Expected call to be bridged within #{timeout} seconds"
+    end
+
     def assert_hungup(agent, timeout: 5)
       assert agent.call?, "Agent has no call"
       success = agent.wait_for_end(timeout: timeout)


### PR DESCRIPTION
## Summary
- Add `assert_answered(agent, timeout: 5)` and `assert_bridged(agent, timeout: 5)` to Scenario
- Add `bridge_echo` dialplan extension that answers and bridges to echo, generating real CHANNEL_BRIDGE events for integration testing
- Update integration tests to use new assertions instead of raw `wait_for_answer` / `assert wait_for_answer` patterns
- Remove dead `wait_for_bridge` calls that silently timed out on loopback+park calls (loopback with `&park` never generates CHANNEL_BRIDGE events)