### PR TITLE
Clean up internals and improve reliability

### DIFF
--- a/docker/freeswitch/dialplan.xml
+++ b/docker/freeswitch/dialplan.xml
@@ -25,6 +25,14 @@
     </condition>
   </extension>
 
+  <!-- Answer and bridge to echo (generates CHANNEL_BRIDGE events) -->
+  <extension name="switest-bridge-echo">
+    <condition field="destination_number" expression="^bridge_echo$">
+      <action application="answer"/>
+      <action application="bridge" data="loopback/echo/public"/>
+    </condition>
+  </extension>
+
   <!-- Inbound test with inband DTMF detection enabled -->
   <extension name="switest-dtmf-detect">
     <condition field="destination_number" expression="^dtmf_wait_test$">

--- a/lib/switest/agent.rb
+++ b/lib/switest/agent.rb
@@ -72,6 +72,11 @@ module Switest
       @call.receive_dtmf(count: count, timeout: timeout)
     end
 
+    def flush_dtmf
+      raise "No call for DTMF" unless @call
+      @call.flush_dtmf
+    end
+
     def wait_for_call(timeout: 5)
       deadline = Time.now + timeout
       while Time.now < deadline

--- a/lib/switest/agent.rb
+++ b/lib/switest/agent.rb
@@ -77,7 +77,9 @@ module Switest
 
     def flush_dtmf
       raise "No call for DTMF" unless call?
-      call.flush_dtmf
+      c = call
+      warn "[DEBUG flush_dtmf] call returned: #{c.class} (complete?=#{@call.complete?}, state=#{@call.instance_variable_get(:@state)}, ivar_id=#{@call.object_id})"
+      c.flush_dtmf
     end
 
     def wait_for_call(timeout: 5)

--- a/lib/switest/agent.rb
+++ b/lib/switest/agent.rb
@@ -43,7 +43,7 @@ module Switest
     end
 
     def call
-      @call.value if @call.complete?
+      @call.value! if @call.complete?
     end
 
     def call?
@@ -81,9 +81,9 @@ module Switest
     end
 
     def wait_for_call(timeout: 5)
-      return true if @call.complete?
-      @call.value(timeout)
-      @call.complete?
+      return true if call?
+      @call.wait(timeout)
+      call?
     end
 
     def wait_for_answer(timeout: 5)

--- a/lib/switest/agent.rb
+++ b/lib/switest/agent.rb
@@ -30,104 +30,105 @@ module Switest
 
         # Register a one-time handler for matching inbound calls
         @events.once(:offer, guards) do |data|
-          agent.instance_variable_set(:@call, data[:call])
+          agent.instance_variable_get(:@call).set(data[:call])
         end
 
         agent
       end
     end
 
-    attr_reader :call
-
     def initialize(call)
-      @call = call
+      @call = Concurrent::IVar.new
+      @call.set(call) if call
     end
 
+    def call
+      @call.value(0)
+    end
+
+
     def call?
-      !@call.nil?
+      @call.complete?
     end
 
     def answer(wait: 5)
-      raise "No call to answer" unless @call
-      @call.answer(wait: wait)
+      raise "No call to answer" unless call
+      call.answer(wait: wait)
     end
 
     def hangup(wait: 5)
-      raise "No call to hangup" unless @call
-      @call.hangup(wait: wait)
+      raise "No call to hangup" unless call
+      call.hangup(wait: wait)
     end
 
     def reject(reason = :decline)
-      raise "No call to reject" unless @call
-      @call.reject(reason)
+      raise "No call to reject" unless call
+      call.reject(reason)
     end
 
     def send_dtmf(digits)
-      raise "No call for DTMF" unless @call
-      @call.send_dtmf(digits)
+      raise "No call for DTMF" unless call
+      call.send_dtmf(digits)
     end
 
     def receive_dtmf(count: 1, timeout: 5)
-      raise "No call for DTMF" unless @call
-      @call.receive_dtmf(count: count, timeout: timeout)
+      raise "No call for DTMF" unless call
+      call.receive_dtmf(count: count, timeout: timeout)
     end
 
     def flush_dtmf
-      raise "No call for DTMF" unless @call
-      @call.flush_dtmf
+      raise "No call for DTMF" unless call
+      call.flush_dtmf
     end
 
     def wait_for_call(timeout: 5)
-      deadline = Time.now + timeout
-      while Time.now < deadline
-        return true if @call
-        sleep 0.1
-      end
-      false
+      return true if @call.complete?
+      @call.value(timeout)
+      @call.complete?
     end
 
     def wait_for_answer(timeout: 5)
-      raise "No call to wait for" unless @call
-      @call.wait_for_answer(timeout: timeout)
+      raise "No call to wait for" unless call
+      call.wait_for_answer(timeout: timeout)
     end
 
     def wait_for_bridge(timeout: 5)
-      raise "No call to wait for" unless @call
-      @call.wait_for_bridge(timeout: timeout)
+      raise "No call to wait for" unless call
+      call.wait_for_bridge(timeout: timeout)
     end
 
     def wait_for_end(timeout: 5)
-      raise "No call to wait for" unless @call
-      @call.wait_for_end(timeout: timeout)
+      raise "No call to wait for" unless call
+      call.wait_for_end(timeout: timeout)
     end
 
     # Delegate state queries to call
     def alive?
-      @call&.alive? || false
+      call&.alive? || false
     end
 
     def active?
-      @call&.active? || false
+      call&.active? || false
     end
 
     def answered?
-      @call&.answered? || false
+      call&.answered? || false
     end
 
     def ended?
-      @call&.ended? || false
+      call&.ended? || false
     end
 
     def start_time
-      @call&.start_time
+      call&.start_time
     end
 
     def answer_time
-      @call&.answer_time
+      call&.answer_time
     end
 
     def end_reason
-      @call&.end_reason
+      call&.end_reason
     end
   end
 end

--- a/lib/switest/agent.rb
+++ b/lib/switest/agent.rb
@@ -43,7 +43,7 @@ module Switest
     end
 
     def call
-      @call.value(0)
+      @call.value if @call.complete?
     end
 
     def call?
@@ -51,32 +51,32 @@ module Switest
     end
 
     def answer(wait: 5)
-      raise "No call to answer" unless call
+      raise "No call to answer" unless call?
       call.answer(wait: wait)
     end
 
     def hangup(wait: 5)
-      raise "No call to hangup" unless call
+      raise "No call to hangup" unless call?
       call.hangup(wait: wait)
     end
 
     def reject(reason = :decline)
-      raise "No call to reject" unless call
+      raise "No call to reject" unless call?
       call.reject(reason)
     end
 
     def send_dtmf(digits)
-      raise "No call for DTMF" unless call
+      raise "No call for DTMF" unless call?
       call.send_dtmf(digits)
     end
 
     def receive_dtmf(count: 1, timeout: 5)
-      raise "No call for DTMF" unless call
+      raise "No call for DTMF" unless call?
       call.receive_dtmf(count: count, timeout: timeout)
     end
 
     def flush_dtmf
-      raise "No call for DTMF" unless call
+      raise "No call for DTMF" unless call?
       call.flush_dtmf
     end
 
@@ -87,47 +87,54 @@ module Switest
     end
 
     def wait_for_answer(timeout: 5)
-      raise "No call to wait for" unless call
+      raise "No call to wait for" unless call?
       call.wait_for_answer(timeout: timeout)
     end
 
     def wait_for_bridge(timeout: 5)
-      raise "No call to wait for" unless call
+      raise "No call to wait for" unless call?
       call.wait_for_bridge(timeout: timeout)
     end
 
     def wait_for_end(timeout: 5)
-      raise "No call to wait for" unless call
+      raise "No call to wait for" unless call?
       call.wait_for_end(timeout: timeout)
     end
 
     # Delegate state queries to call
     def alive?
-      call&.alive? || false
+      return false unless call?
+      call.alive?
     end
 
     def active?
-      call&.active? || false
+      return false unless call?
+      call.active?
     end
 
     def answered?
-      call&.answered? || false
+      return false unless call?
+      call.answered?
     end
 
     def ended?
-      call&.ended? || false
+      return false unless call?
+      call.ended?
     end
 
     def start_time
-      call&.start_time
+      return unless call?
+      call.start_time
     end
 
     def answer_time
-      call&.answer_time
+      return unless call?
+      call.answer_time
     end
 
     def end_reason
-      call&.end_reason
+      return unless call?
+      call.end_reason
     end
   end
 end

--- a/lib/switest/agent.rb
+++ b/lib/switest/agent.rb
@@ -46,7 +46,6 @@ module Switest
       @call.value(0)
     end
 
-
     def call?
       @call.complete?
     end

--- a/lib/switest/esl/call.rb
+++ b/lib/switest/esl/call.rb
@@ -98,6 +98,10 @@ module Switest
         play_audio("tone_stream://d=200;w=250;#{digits}", wait: wait)
       end
 
+      def flush_dtmf
+        @dtmf_buffer.clear
+      end
+
       def receive_dtmf(count: 1, timeout: 5)
         digits = String.new
         deadline = Time.now + timeout

--- a/lib/switest/esl/connection.rb
+++ b/lib/switest/esl/connection.rb
@@ -110,8 +110,11 @@ module Switest
 
       def subscribe_events
         events = %w[
-          CHANNEL_CREATE CHANNEL_ANSWER CHANNEL_BRIDGE CHANNEL_HANGUP
-          CHANNEL_HANGUP_COMPLETE CHANNEL_EXECUTE_COMPLETE DTMF CHANNEL_STATE
+          CHANNEL_CREATE           # Detect new inbound calls
+          CHANNEL_ANSWER           # Track when calls are answered
+          CHANNEL_BRIDGE           # Track when calls are bridged
+          CHANNEL_HANGUP_COMPLETE  # Track call end with final headers
+          DTMF                     # Receive DTMF digits per call
         ].join(" ")
 
         @socket.write("event plain #{events}\n\n")

--- a/lib/switest/scenario.rb
+++ b/lib/switest/scenario.rb
@@ -79,7 +79,7 @@ module Switest
       if block
         agent.flush_dtmf
         Concurrent::ScheduledTask.execute(after) { block.call }
-        received = agent.receive_dtmf(count: expected_dtmf.length, timeout: timeout)
+        received = agent.receive_dtmf(count: expected_dtmf.length, timeout: timeout + after)
       else
         received = agent.receive_dtmf(count: expected_dtmf.length, timeout: timeout)
       end

--- a/lib/switest/scenario.rb
+++ b/lib/switest/scenario.rb
@@ -49,6 +49,18 @@ module Switest
       refute agent.call?, "Expected agent to not have received a call"
     end
 
+    def assert_answered(agent, timeout: 5)
+      assert agent.call?, "Agent has no call"
+      success = agent.wait_for_answer(timeout: timeout)
+      assert success, "Expected call to be answered within #{timeout} seconds"
+    end
+
+    def assert_bridged(agent, timeout: 5)
+      assert agent.call?, "Agent has no call"
+      success = agent.wait_for_bridge(timeout: timeout)
+      assert success, "Expected call to be bridged within #{timeout} seconds"
+    end
+
     def assert_hungup(agent, timeout: 5)
       assert agent.call?, "Agent has no call"
       success = agent.wait_for_end(timeout: timeout)

--- a/lib/switest/scenario.rb
+++ b/lib/switest/scenario.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "minitest/test"
+require "concurrent"
 
 module Switest
   class Scenario < Minitest::Test
@@ -60,9 +61,17 @@ module Switest
       refute agent.ended?, "Expected call to still be active"
     end
 
-    def assert_dtmf(agent, expected_dtmf, timeout: 5)
+    def assert_dtmf(agent, expected_dtmf, timeout: 5, after: 1, &block)
       assert agent.call?, "Agent has no call"
-      received = agent.receive_dtmf(count: expected_dtmf.length, timeout: timeout)
+
+      if block
+        agent.flush_dtmf
+        Concurrent::ScheduledTask.execute(after) { block.call }
+        received = agent.receive_dtmf(count: expected_dtmf.length, timeout: timeout)
+      else
+        received = agent.receive_dtmf(count: expected_dtmf.length, timeout: timeout)
+      end
+
       assert_equal expected_dtmf, received, "Expected DTMF '#{expected_dtmf}' but received '#{received}'"
     end
   end

--- a/lib/switest/version.rb
+++ b/lib/switest/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Switest
-  VERSION = "0.1.1"
+  VERSION = "0.4.0"
 end

--- a/test/integration/call_test.rb
+++ b/test/integration/call_test.rb
@@ -16,9 +16,6 @@ class CallIntegrationTest < Switest::Scenario
     assert alice.call?, "Agent should have a call after dial"
     assert alice.call.outbound?, "Call should be outbound"
 
-    # Wait for the loopback legs to bridge
-    alice.wait_for_bridge(timeout: 5)
-
     # Hangup
     alice.hangup
 
@@ -34,9 +31,7 @@ class CallIntegrationTest < Switest::Scenario
     assert alice.call?, "Agent should have a call"
 
     # Wait for the call to be answered
-    answered = alice.wait_for_answer(timeout: 5)
-    assert answered, "Call should be answered"
-    assert alice.answered?, "Agent should show call as answered"
+    assert_answered(alice)
 
     # Clean up
     alice.hangup
@@ -163,15 +158,14 @@ class CallIntegrationTest < Switest::Scenario
     assert alice.call?, "Alice should have outbound call"
 
     # Bob should receive the inbound call (B-leg)
-    assert bob.wait_for_call(timeout: 5), "Bob should receive inbound call"
-    assert bob.call?, "Bob should have a call"
+    assert_call(bob)
     assert bob.call.inbound?, "Bob's call should be inbound"
 
     # Bob answers (wait for answer to complete)
     bob.answer
 
     # Both should now be connected
-    assert alice.wait_for_answer(timeout: 5), "Alice should see answer"
+    assert_answered(alice)
     assert bob.answered?, "Bob should be answered"
 
     # Cleanup
@@ -185,7 +179,7 @@ class CallIntegrationTest < Switest::Scenario
 
     alice = Agent.dial("loopback/reject_test/public")
 
-    assert bob.wait_for_call(timeout: 5), "Bob should receive call"
+    assert_call(bob)
 
     # Bob rejects the call
     bob.reject(:busy)
@@ -209,8 +203,8 @@ class CallIntegrationTest < Switest::Scenario
     refute_equal alice.call.id, bob.call.id, "Calls should have different IDs"
 
     # Wait for both to answer (longer timeout for CI)
-    assert alice.wait_for_answer(timeout: 10), "Alice should be answered"
-    assert bob.wait_for_answer(timeout: 10), "Bob should be answered"
+    assert_answered(alice, timeout: 10)
+    assert_answered(bob, timeout: 10)
 
     # Hangup both (wait for completion)
     alice.hangup(wait: 15)
@@ -303,8 +297,8 @@ class CallIntegrationTest < Switest::Scenario
     refute_equal alice.call.id, bob.call.id, "Calls should have different IDs"
 
     # Wait for both to answer
-    assert alice.wait_for_answer(timeout: 5), "Alice should be answered"
-    assert bob.wait_for_answer(timeout: 5), "Bob should be answered"
+    assert_answered(alice)
+    assert_answered(bob)
 
     # Each call should receive its own DTMF digits
     alice_digits = alice.call.receive_dtmf(count: 3, timeout: 5)
@@ -344,9 +338,9 @@ class CallIntegrationTest < Switest::Scenario
     charlie = Agent.dial("loopback/echo/public")
 
     # Wait for all to answer
-    assert alice.wait_for_answer(timeout: 5), "Alice should be answered"
-    assert bob.wait_for_answer(timeout: 5), "Bob should be answered"
-    assert charlie.wait_for_answer(timeout: 5), "Charlie should be answered"
+    assert_answered(alice)
+    assert_answered(bob)
+    assert_answered(charlie)
 
     # All calls should be active
     assert alice.active?, "Alice should be active"
@@ -369,7 +363,7 @@ class CallIntegrationTest < Switest::Scenario
 
   def test_hangup_all_with_custom_cause
     alice = Agent.dial("loopback/echo/public")
-    assert alice.wait_for_answer(timeout: 5), "Alice should be answered"
+    assert_answered(alice)
 
     # Hangup with custom cause
     hangup_all(cause: "USER_BUSY")
@@ -386,7 +380,7 @@ class CallIntegrationTest < Switest::Scenario
 
     assert_call(bob)
     bob.answer
-    assert alice.wait_for_answer(timeout: 5), "Alice should be answered"
+    assert_answered(alice)
 
     # Alice plays DTMF tones — B-leg's start_dtmf should detect them
     assert_dtmf(bob, "789") do
@@ -397,12 +391,23 @@ class CallIntegrationTest < Switest::Scenario
     bob.wait_for_end(timeout: 5)
   end
 
+  def test_bridge_via_dialplan
+    # Listen for the loopback B-leg that will hit the bridge_echo dialplan
+    bob = Agent.listen_for_call(to: /bridge_echo/)
+
+    # The B-leg answers and bridges to echo via the dialplan
+    alice = Agent.dial("loopback/bridge_echo/public")
+
+    assert_call(bob)
+    assert_bridged(bob)
+
+    alice.hangup
+    bob.wait_for_end
+  end
+
   def test_hangup_headers_are_available_after_call_ends
     alice = Agent.dial("loopback/echo/public")
-    assert alice.wait_for_answer(timeout: 5), "Alice should be answered"
-
-    # Wait for bridge so we get some duration
-    alice.wait_for_bridge(timeout: 5)
+    assert_answered(alice)
 
     alice.hangup
     assert alice.ended?, "Alice should be ended"

--- a/test/integration/call_test.rb
+++ b/test/integration/call_test.rb
@@ -384,16 +384,14 @@ class CallIntegrationTest < Switest::Scenario
 
     alice = Agent.dial("loopback/dtmf_wait_test/public")
 
-    assert bob.wait_for_call(timeout: 5), "Bob should receive call"
+    assert_call(bob)
     bob.answer
     assert alice.wait_for_answer(timeout: 5), "Alice should be answered"
-    alice.wait_for_bridge(timeout: 5)
 
     # Alice plays DTMF tones — B-leg's start_dtmf should detect them
-    alice.call.send_dtmf("789")
-
-    digits = bob.call.receive_dtmf(count: 3, timeout: 5)
-    assert_equal "789", digits, "Bob should receive DTMF digits from Alice"
+    assert_dtmf(bob, "789") do
+      alice.send_dtmf("789")
+    end
 
     alice.hangup
     bob.wait_for_end(timeout: 5)

--- a/test/unit/switest/esl/call_test.rb
+++ b/test/unit/switest/esl/call_test.rb
@@ -260,6 +260,22 @@ class Switest::ESL::CallTest < Minitest::Test
     assert_equal "123", digits
   end
 
+  def test_flush_dtmf_clears_buffer
+    call = Switest::ESL::Call.new(
+      id: "test-uuid",
+      connection: @connection,
+      direction: :inbound
+    )
+
+    call.handle_dtmf("1")
+    call.handle_dtmf("2")
+    call.flush_dtmf
+
+    call.handle_dtmf("3")
+    digits = call.receive_dtmf(count: 1, timeout: 1)
+    assert_equal "3", digits
+  end
+
   def test_dtmf_timeout
     call = Switest::ESL::Call.new(
       id: "test-uuid",


### PR DESCRIPTION
## Summary

- Replace `wait_for_call` sleep-polling with `Concurrent::IVar` for instant, zero-waste wakeup
- Add `assert_answered` and `assert_bridged` assertions
- Add block support to `assert_dtmf` to avoid stale DTMF
- Fix `assert_dtmf` timeout to account for block delay
- Remove unused ESL event subscriptions and fix `hangup_all` performance
- Update README and bump version to 0.4.0