### PR TITLE
Fix unused variable warnings in rescue clauses

### DIFF
--- a/lib/switest/esl/client.rb
+++ b/lib/switest/esl/client.rb
@@ -87,7 +87,7 @@ module Switest
         # Originate call (park it so we control it)
         begin
           @connection.bgapi("originate #{var_string}#{to} &park")
-        rescue => e
+        rescue
           @calls.delete(uuid)
           raise
         end

--- a/lib/switest/esl/connection.rb
+++ b/lib/switest/esl/connection.rb
@@ -150,7 +150,7 @@ module Switest
           rescue IOError, Errno::EBADF, Errno::ECONNRESET
             # Socket closed
             break
-          rescue => e
+          rescue
             # Log but continue on other errors
             break unless @running
           end


### PR DESCRIPTION
## Summary
- Remove unused `e` variable from `rescue => e` in `client.rb` and `connection.rb` to silence Ruby warnings