### PR TITLE
Rename command to send_message for librevox 1.0

### DIFF
--- a/lib/switest/call.rb
+++ b/lib/switest/call.rb
@@ -189,7 +189,7 @@ module Switest
       msg << "execute-app-arg: #{arg}\n" if arg
       msg << "event-lock: true\n" if event_lock
       msg << "hangup-cause: #{hangup_cause}" if hangup_cause
-      @session.command(msg.chomp)
+      @session.send_message(msg.chomp)
     end
 
   end

--- a/lib/switest/session.rb
+++ b/lib/switest/session.rb
@@ -43,7 +43,7 @@ module Switest
     end
 
     def bgapi(cmd)
-      command("bgapi #{cmd}")
+      send_message("bgapi #{cmd}")
     end
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -26,13 +26,13 @@ module Switest
         @commands_sent = []
       end
 
-      def command(msg)
+      def send_message(msg)
         @commands_sent << msg
         mock_response
       end
 
       def bgapi(cmd)
-        command("bgapi #{cmd}")
+        send_message("bgapi #{cmd}")
       end
 
       private


### PR DESCRIPTION
## Summary
- Renames `command` → `send_message` in Session, Call, and MockSession to match the librevox 1.0 API rename