### PR TITLE
Fix module comment indentation

### DIFF
--- a/lib/switest/escaper.rb
+++ b/lib/switest/escaper.rb
@@ -2,17 +2,17 @@
 
 module Switest
   # Escapes values for use in FreeSWITCH channel variable strings.
-    #
-    # FreeSWITCH originate syntax: {var1=value1,var2=value2}endpoint
-    #
-    # Escaping rules (per FreeSWITCH documentation):
-    # - Spaces: wrap value in single quotes
-    # - Commas in regular vars: use ^^<delim> syntax (e.g., ^^:val1:val2)
-    # - Commas in SIP headers (sip_h_*): escape with backslash (\,)
-    # - Single quotes in quoted values: escape with backslash (\')
-    #
-    # @see https://developer.signalwire.com/freeswitch/FreeSWITCH-Explained/Dialplan/Channel-Variables_16352493/
-    module Escaper
+  #
+  # FreeSWITCH originate syntax: {var1=value1,var2=value2}endpoint
+  #
+  # Escaping rules (per FreeSWITCH documentation):
+  # - Spaces: wrap value in single quotes
+  # - Commas in regular vars: use ^^<delim> syntax (e.g., ^^:val1:val2)
+  # - Commas in SIP headers (sip_h_*): escape with backslash (\,)
+  # - Single quotes in quoted values: escape with backslash (\')
+  #
+  # @see https://developer.signalwire.com/freeswitch/FreeSWITCH-Explained/Dialplan/Channel-Variables_16352493/
+  module Escaper
       module_function
 
       # Characters that require the value to be quoted

--- a/lib/switest/from_parser.rb
+++ b/lib/switest/from_parser.rb
@@ -2,16 +2,16 @@
 
 module Switest
   # Parses a `from` string into FreeSWITCH channel variables,
-    # replicating mod_rayo's parse_dial_from() behavior.
-    #
-    # Algorithm (matching mod_rayo):
-    # 1. Split on last space — before = display name, after = URI
-    # 2. No space — entire string is URI, no display name
-    # 3. Strip "" from display name (if quoted)
-    # 4. Strip <> from URI (if angle-bracketed)
-    # 5. Detect scheme: sip:/sips: with @ → SIP, tel: → TEL, plain → TEL, empty → UNKNOWN
-    # 6. Map to FreeSWITCH variables accordingly
-    module FromParser
+  # replicating mod_rayo's parse_dial_from() behavior.
+  #
+  # Algorithm (matching mod_rayo):
+  # 1. Split on last space — before = display name, after = URI
+  # 2. No space — entire string is URI, no display name
+  # 3. Strip "" from display name (if quoted)
+  # 4. Strip <> from URI (if angle-bracketed)
+  # 5. Detect scheme: sip:/sips: with @ → SIP, tel: → TEL, plain → TEL, empty → UNKNOWN
+  # 6. Map to FreeSWITCH variables accordingly
+  module FromParser
       module_function
 
       SIP_URI_PATTERN = /\Asips?:.+@/


### PR DESCRIPTION
## Summary
- Fix inconsistent indentation in module-level comments in `from_parser.rb` and `escaper.rb`
- Comment continuation lines were at 4 spaces instead of 2, now consistent with module nesting